### PR TITLE
Fix README usage formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Please ensure:
   - Your codefresh account enabled for CustomKubernetesCluster feature
 
 Usage:
+```sh
   ./codefresh-k8s-configure.sh [ options ] cluster_name
 
   options:
@@ -17,7 +18,7 @@ Usage:
   --namespace <kubernetes namespace>
   --context <kubectl context>
   --image-tag <codefresh/k8s-dind-config image tag - default latest>
-  
+```
   
 It will submit pod with codefresh-configure-$(date '+%Y-%m-%d-%H%M%S'):
 
@@ -53,8 +54,3 @@ spec:
       - name: CLUSTER_NAME
         value: "${CLUSTER_NAME}"
 ```
-
-≈
-  
-  
-


### PR DESCRIPTION
The current configure script usage section hides replacements in the README. This just formats usage as a shell block.

### Before:

Usage: ./codefresh-k8s-configure.sh [ options ] cluster_name

options: --api-token - default $API_TOKEN --registry-token - default $REGISTRY_TOKEN --namespace --context --image-tag <codefresh/k8s-dind-config image tag - default latest>

### After:

```sh
  ./codefresh-k8s-configure.sh [ options ] cluster_name

  options:
  --api-token <codefresh api token> - default $API_TOKEN
  --registry-token <codefresh registry token> - default $REGISTRY_TOKEN
  --namespace <kubernetes namespace>
  --context <kubectl context>
  --image-tag <codefresh/k8s-dind-config image tag - default latest>
```